### PR TITLE
[REC-202] Add `User-Agent` header to all outgoing requests

### DIFF
--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -10,6 +10,7 @@ use crate::{
     middlewares::{
         authentication::AuthenticationMiddleware,
         error_handling::ErrorHandlingMiddleware,
+        inject_user_agent::InjectUserAgentMiddleware,
         retry_idempotent::{DynRetryPolicy, RetryIdempotentMiddleware},
         signing::SigningMiddleware,
     },
@@ -187,6 +188,7 @@ fn build_client_with_middleware(
     signing_middleware: Option<SigningMiddleware>,
 ) -> ClientWithMiddleware {
     let mut builder = reqwest_middleware::ClientBuilder::new(client)
+        .with(InjectUserAgentMiddleware::new())
         .with(TracingMiddleware)
         .with(ErrorHandlingMiddleware);
 

--- a/sdk/src/middlewares/inject_user_agent.rs
+++ b/sdk/src/middlewares/inject_user_agent.rs
@@ -1,0 +1,37 @@
+use async_trait::async_trait;
+use reqwest::{
+    header::{HeaderValue, USER_AGENT},
+    Request, Response,
+};
+use reqwest_middleware::{Middleware, Next};
+use task_local_extensions::Extensions;
+
+/// Middleware to inject the `User-Agent` header to all outgoing requests.
+pub struct InjectUserAgentMiddleware {
+    user_agent: HeaderValue,
+}
+
+impl InjectUserAgentMiddleware {
+    pub fn new() -> Self {
+        Self {
+            user_agent: concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"))
+                .parse()
+                .unwrap(),
+        }
+    }
+}
+
+#[async_trait]
+impl Middleware for InjectUserAgentMiddleware {
+    async fn handle(
+        &self,
+        mut req: Request,
+        extensions: &mut Extensions,
+        next: Next<'_>,
+    ) -> reqwest_middleware::Result<Response> {
+        req.headers_mut()
+            .insert(USER_AGENT, self.user_agent.clone());
+
+        next.run(req, extensions).await
+    }
+}

--- a/sdk/src/middlewares/mod.rs
+++ b/sdk/src/middlewares/mod.rs
@@ -1,4 +1,5 @@
 pub mod authentication;
 pub mod error_handling;
+pub mod inject_user_agent;
 pub mod retry_idempotent;
 pub mod signing;


### PR DESCRIPTION
Introduce a new middleware `InjectUserAgentMiddleware` to inject a `User-Agent` header to all outgoing requests.