### PR TITLE
[REC-202] Hide idempotency key from public interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,6 +1456,7 @@ dependencies = [
  "tokio",
  "tracing",
  "truelayer-signing",
+ "uuid",
  "wiremock",
 ]
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -57,26 +57,23 @@ async fn run() -> anyhow::Result<()> {
     // Create a new outgoing payment
     let res = tl
         .payments
-        .create(
-            &CreatePaymentRequest {
-                amount_in_minor: 100,
-                currency: Currency::Gbp,
-                payment_method: PaymentMethod::BankTransfer {
-                    provider_selection: ProviderSelection::UserSelected { filter: None },
-                    beneficiary: Beneficiary::MerchantAccount {
-                        merchant_account_id: "00000000-0000-0000-0000-000000000000".to_string(),
-                        account_holder_name: None,
-                    },
-                },
-                user: User {
-                    id: Some(Uuid::new_v4().to_string()),
-                    name: Some("Some One".to_string()),
-                    email: Some("some.one@email.com".to_string()),
-                    phone: None,
+        .create(&CreatePaymentRequest {
+            amount_in_minor: 100,
+            currency: Currency::Gbp,
+            payment_method: PaymentMethod::BankTransfer {
+                provider_selection: ProviderSelection::UserSelected { filter: None },
+                beneficiary: Beneficiary::MerchantAccount {
+                    merchant_account_id: "00000000-0000-0000-0000-000000000000".to_string(),
+                    account_holder_name: None,
                 },
             },
-            &Uuid::new_v4().to_string(),
-        )
+            user: User {
+                id: Some(Uuid::new_v4().to_string()),
+                name: Some("Some One".to_string()),
+                email: Some("some.one@email.com".to_string()),
+                phone: None,
+            },
+        })
         .await?;
 
     tracing::info!("Created new payment: {}", res.id);

--- a/truelayer-rust/Cargo.toml
+++ b/truelayer-rust/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = "1.0"
 tokio = { version = "1", features = [ "rt", "macros", "sync" ] }
 tracing = "0.1"
 truelayer-signing = "0.1"
+uuid = "0.8.2"
 
 [dev-dependencies]
 futures = "0.3"

--- a/truelayer-rust/src/client.rs
+++ b/truelayer-rust/src/client.rs
@@ -7,6 +7,11 @@ use crate::{
         TrueLayerClientInner,
     },
     authenticator::Authenticator,
+    common::{
+        DEFAULT_AUTH_URL, DEFAULT_HOSTED_PAYMENTS_PAGE_URL, DEFAULT_PAYMENTS_URL,
+        DEFAULT_SANDBOX_AUTH_URL, DEFAULT_SANDBOX_HOSTED_PAYMENTS_PAGE_URL,
+        DEFAULT_SANDBOX_PAYMENTS_URL,
+    },
     middlewares::{
         authentication::AuthenticationMiddleware,
         error_handling::ErrorHandlingMiddleware,
@@ -20,13 +25,6 @@ use reqwest_middleware::ClientWithMiddleware;
 use reqwest_retry::{policies::ExponentialBackoff, RetryPolicy};
 use reqwest_tracing::TracingMiddleware;
 use std::sync::Arc;
-
-static DEFAULT_AUTH_URL: &str = "https://auth.truelayer.com";
-static DEFAULT_PAYMENTS_URL: &str = "https://test-pay-api.truelayer.com";
-static DEFAULT_HOSTED_PAYMENTS_PAGE_URL: &str = "https://payment.truelayer.com";
-static DEFAULT_SANDBOX_AUTH_URL: &str = "https://auth.truelayer-sandbox.com";
-static DEFAULT_SANDBOX_PAYMENTS_URL: &str = "https://test-pay-api.truelayer-sandbox.com";
-static DEFAULT_SANDBOX_HOSTED_PAYMENTS_PAGE_URL: &str = "https://payment.truelayer-sandbox.com";
 
 /// Client for TrueLayer public APIs.
 ///

--- a/truelayer-rust/src/common.rs
+++ b/truelayer-rust/src/common.rs
@@ -1,0 +1,11 @@
+// Default URLs
+pub static DEFAULT_AUTH_URL: &str = "https://auth.truelayer.com";
+pub static DEFAULT_PAYMENTS_URL: &str = "https://test-pay-api.truelayer.com";
+pub static DEFAULT_HOSTED_PAYMENTS_PAGE_URL: &str = "https://payment.truelayer.com";
+pub static DEFAULT_SANDBOX_AUTH_URL: &str = "https://auth.truelayer-sandbox.com";
+pub static DEFAULT_SANDBOX_PAYMENTS_URL: &str = "https://test-pay-api.truelayer-sandbox.com";
+pub static DEFAULT_SANDBOX_HOSTED_PAYMENTS_PAGE_URL: &str = "https://payment.truelayer-sandbox.com";
+
+// Header names
+pub static IDEMPOTENCY_KEY_HEADER: &str = "Idempotency-Key";
+pub static TL_SIGNATURE_HEADER: &str = "Tl-Signature";

--- a/truelayer-rust/src/lib.rs
+++ b/truelayer-rust/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod apis;
 pub(crate) mod authenticator;
 pub mod client;
+mod common;
 pub mod error;
 mod middlewares;
 pub mod pollable;

--- a/truelayer-rust/src/middlewares/retry_idempotent.rs
+++ b/truelayer-rust/src/middlewares/retry_idempotent.rs
@@ -1,3 +1,4 @@
+use crate::common::IDEMPOTENCY_KEY_HEADER;
 use async_trait::async_trait;
 use reqwest::{Method, Request, Response};
 use reqwest_middleware::{Middleware, Next};
@@ -8,8 +9,6 @@ use std::{
     sync::Arc,
 };
 use task_local_extensions::Extensions;
-
-static IDEMPOTENCY_KEY_HEADER: &str = "Idempotency-Key";
 
 /// Middleware that automatically retries transient failures only on idempotent requests.
 ///

--- a/truelayer-rust/src/middlewares/signing.rs
+++ b/truelayer-rust/src/middlewares/signing.rs
@@ -1,11 +1,11 @@
-use crate::error::Error;
+use crate::{
+    common::{IDEMPOTENCY_KEY_HEADER, TL_SIGNATURE_HEADER},
+    error::Error,
+};
 use async_trait::async_trait;
 use reqwest::{header::HeaderValue, Method, Request, Response};
 use reqwest_middleware::{Middleware, Next};
 use task_local_extensions::Extensions;
-
-static IDEMPOTENCY_KEY_HEADER: &str = "Idempotency-Key";
-static TL_SIGNATURE_HEADER: &str = "Tl-Signature";
 
 /// Middleware to attach signatures to all outgoing `POST`, `PUT` and `DELETE` requests.
 ///


### PR DESCRIPTION
Idempotency keys should be hidden from the user and used only internally for the automatic retry mechanism.

This PR also groups all the constants that were scattered throughout the codebase in a single module.