### PR TITLE
[REC-202] Rename `payment_token` to `resource_token`

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -84,7 +84,7 @@ async fn run() -> anyhow::Result<()> {
     tracing::info!(
         "HPP Link: {}",
         tl.payments
-            .get_hosted_payments_page_link(&res.id, &res.payment_token, config.return_uri.as_str())
+            .get_hosted_payments_page_link(&res.id, &res.resource_token, config.return_uri.as_str())
             .await
     );
 

--- a/truelayer-rust/src/apis/payments/api.rs
+++ b/truelayer-rust/src/apis/payments/api.rs
@@ -95,14 +95,14 @@ impl PaymentsApi {
     pub async fn get_hosted_payments_page_link(
         &self,
         payment_id: &str,
-        payment_token: &str,
+        resource_token: &str,
         return_uri: &str,
     ) -> Url {
         let mut new_uri = self.inner.environment.hpp_url().join("/payments").unwrap();
 
         new_uri.set_fragment(Some(&format!(
-            "payment_id={}&payment_token={}&return_uri={}",
-            payment_id, payment_token, return_uri
+            "payment_id={}&resource_token={}&return_uri={}",
+            payment_id, resource_token, return_uri
         )));
 
         new_uri
@@ -184,7 +184,7 @@ mod tests {
             })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "id": "payment-id",
-                "payment_token": "payment-token",
+                "resource_token": "resource-token",
                 "user": {
                     "id": "user-id"
                 }
@@ -215,7 +215,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(res.id, "payment-id");
-        assert_eq!(res.payment_token, "payment-token");
+        assert_eq!(res.resource_token, "resource-token");
         assert_eq!(res.user.id, "user-id");
     }
 

--- a/truelayer-rust/src/apis/payments/model.rs
+++ b/truelayer-rust/src/apis/payments/model.rs
@@ -16,7 +16,7 @@ pub struct CreatePaymentRequest {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CreatePaymentResponse {
     pub id: String,
-    pub payment_token: String,
+    pub resource_token: String,
     pub user: CreatePaymentUserResponse,
 }
 

--- a/truelayer-rust/tests/apis/payments.rs
+++ b/truelayer-rust/tests/apis/payments.rs
@@ -36,7 +36,7 @@ async fn create_payment() {
 
     // Assert that we got sensible values back
     assert!(!res.id.is_empty());
-    assert!(!res.payment_token.is_empty());
+    assert!(!res.resource_token.is_empty());
     assert!(!res.user.id.is_empty());
 
     // Fetch the same payment

--- a/truelayer-rust/tests/common/mock_server/routes.rs
+++ b/truelayer-rust/tests/common/mock_server/routes.rs
@@ -63,7 +63,7 @@ pub(super) async fn create_payment(
 
     HttpResponse::Created().json(json!({
         "id": id,
-        "payment_token": format!("payment-token-{}", id),
+        "resource_token": format!("resource-token-{}", id),
         "user": {
             "id": user_id
         }


### PR DESCRIPTION
Rename the `payment_token` returned during payment creation to `resource_token`.