### PR TITLE
[REC-202] Update domain names and models

### DIFF
--- a/truelayer-rust/src/apis/payments/api.rs
+++ b/truelayer-rust/src/apis/payments/api.rs
@@ -333,10 +333,10 @@ mod tests {
             .start_authorization_flow(
                 payment_id,
                 &StartAuthorizationFlowRequest {
-                    provider_selection: ProviderSelectionSupported::Supported,
-                    redirect: RedirectSupported::Supported {
+                    provider_selection: Some(ProviderSelectionSupported {}),
+                    redirect: Some(RedirectSupported {
                         return_uri: "https://my.return.uri".to_string(),
-                    },
+                    }),
                 },
             )
             .await

--- a/truelayer-rust/src/apis/payments/model.rs
+++ b/truelayer-rust/src/apis/payments/model.rs
@@ -276,22 +276,16 @@ pub enum RedirectActionMetadata {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct AuthorizationFlowConfiguration {
-    pub provider_selection: ProviderSelectionSupported,
-    pub redirect: RedirectSupported,
+    pub provider_selection: Option<ProviderSelectionSupported>,
+    pub redirect: Option<RedirectSupported>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
-#[serde(tag = "status", rename_all = "snake_case")]
-pub enum ProviderSelectionSupported {
-    NotSupported,
-    Supported,
-}
+pub struct ProviderSelectionSupported {}
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
-#[serde(tag = "status", rename_all = "snake_case")]
-pub enum RedirectSupported {
-    NotSupported,
-    Supported { return_uri: String },
+pub struct RedirectSupported {
+    pub return_uri: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
@@ -304,16 +298,8 @@ pub struct User {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct StartAuthorizationFlowRequest {
-    #[serde(
-        skip_serializing_if = "skip_serializing_provider_selection_supported",
-        default = "default_provider_selection_supported"
-    )]
-    pub provider_selection: ProviderSelectionSupported,
-    #[serde(
-        skip_serializing_if = "skip_serializing_redirect_supported",
-        default = "default_redirect_supported"
-    )]
-    pub redirect: RedirectSupported,
+    pub provider_selection: Option<ProviderSelectionSupported>,
+    pub redirect: Option<RedirectSupported>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
@@ -343,20 +329,4 @@ pub enum AuthorizationFlowResponseStatus {
         failure_stage: FailureStage,
         failure_reason: String,
     },
-}
-
-fn skip_serializing_provider_selection_supported(val: &ProviderSelectionSupported) -> bool {
-    *val == ProviderSelectionSupported::NotSupported
-}
-
-fn skip_serializing_redirect_supported(val: &RedirectSupported) -> bool {
-    *val == RedirectSupported::NotSupported
-}
-
-fn default_provider_selection_supported() -> ProviderSelectionSupported {
-    ProviderSelectionSupported::NotSupported
-}
-
-fn default_redirect_supported() -> RedirectSupported {
-    RedirectSupported::NotSupported
 }

--- a/truelayer-rust/src/common.rs
+++ b/truelayer-rust/src/common.rs
@@ -1,9 +1,9 @@
 // Default URLs
 pub static DEFAULT_AUTH_URL: &str = "https://auth.truelayer.com";
-pub static DEFAULT_PAYMENTS_URL: &str = "https://test-pay-api.truelayer.com";
+pub static DEFAULT_PAYMENTS_URL: &str = "https://api.truelayer.com";
 pub static DEFAULT_HOSTED_PAYMENTS_PAGE_URL: &str = "https://payment.truelayer.com";
 pub static DEFAULT_SANDBOX_AUTH_URL: &str = "https://auth.truelayer-sandbox.com";
-pub static DEFAULT_SANDBOX_PAYMENTS_URL: &str = "https://test-pay-api.truelayer-sandbox.com";
+pub static DEFAULT_SANDBOX_PAYMENTS_URL: &str = "https://api.truelayer-sandbox.com";
 pub static DEFAULT_SANDBOX_HOSTED_PAYMENTS_PAGE_URL: &str = "https://payment.truelayer-sandbox.com";
 
 // Header names

--- a/truelayer-rust/tests/apis/payments.rs
+++ b/truelayer-rust/tests/apis/payments.rs
@@ -134,10 +134,10 @@ async fn complete_authorization_flow() {
         .start_authorization_flow(
             &res.id,
             &StartAuthorizationFlowRequest {
-                provider_selection: ProviderSelectionSupported::Supported,
-                redirect: RedirectSupported::Supported {
+                provider_selection: Some(ProviderSelectionSupported {}),
+                redirect: Some(RedirectSupported {
                     return_uri: "https://my.return.uri".to_string(),
-                },
+                }),
             },
         )
         .await


### PR DESCRIPTION
The domain `test-pay-api.*.*` has been renamed to `api.*.*`.

Update the default URLs and the models to the latest specs.