### PR TITLE
feat: [PAYG-856] Add consent action

### DIFF
--- a/examples/create_payment.rs
+++ b/examples/create_payment.rs
@@ -3,8 +3,8 @@ use truelayer_rust::{
     apis::{
         auth::Credentials,
         payments::{
-            Beneficiary, CreatePaymentRequest, CreatePaymentUserRequest, Currency, PaymentMethod,
-            ProviderSelection,
+            Beneficiary, CreatePaymentRequest, CreatePaymentUserRequest, Currency,
+            PaymentMethodRequest, ProviderSelectionRequest,
         },
     },
     client::Environment,
@@ -68,8 +68,8 @@ async fn run() -> anyhow::Result<()> {
         .create(&CreatePaymentRequest {
             amount_in_minor: 100,
             currency: Currency::Gbp,
-            payment_method: PaymentMethod::BankTransfer {
-                provider_selection: ProviderSelection::UserSelected { filter: None },
+            payment_method: PaymentMethodRequest::BankTransfer {
+                provider_selection: ProviderSelectionRequest::UserSelected { filter: None },
                 beneficiary: Beneficiary::MerchantAccount {
                     merchant_account_id: merchant_account.id,
                     account_holder_name: None,

--- a/src/apis/payments/api.rs
+++ b/src/apis/payments/api.rs
@@ -285,9 +285,9 @@ mod tests {
             payments::{
                 AdditionalInputType, AuthorizationFlowNextAction, AuthorizationFlowResponseStatus,
                 Beneficiary, ConsentSupported, CountryCode, CreatePaymentUserRequest, Currency,
-                FailureStage, FormSupported, PaymentMethod, PaymentStatus, Provider,
-                ProviderSelection, ProviderSelectionSupported, RedirectSupported,
-                SubmitProviderReturnParametersResponseResource, User,
+                FailureStage, FormSupported, PaymentMethod, PaymentMethodRequest, PaymentStatus,
+                Provider, ProviderSelection, ProviderSelectionRequest, ProviderSelectionSupported,
+                RedirectSupported, SubmitProviderReturnParametersResponseResource, User,
             },
         },
         authenticator::Authenticator,
@@ -369,8 +369,8 @@ mod tests {
             .create(&CreatePaymentRequest {
                 amount_in_minor: 100,
                 currency: Currency::Gbp,
-                payment_method: PaymentMethod::BankTransfer {
-                    provider_selection: ProviderSelection::UserSelected { filter: None },
+                payment_method: PaymentMethodRequest::BankTransfer {
+                    provider_selection: ProviderSelectionRequest::UserSelected { filter: None },
                     beneficiary: Beneficiary::MerchantAccount {
                         merchant_account_id: "merchant-account-id".to_string(),
                         account_holder_name: None,
@@ -735,7 +735,11 @@ mod tests {
         assert_eq!(
             payment.payment_method,
             PaymentMethod::BankTransfer {
-                provider_selection: ProviderSelection::UserSelected { filter: None },
+                provider_selection: ProviderSelection::UserSelected {
+                    filter: None,
+                    provider_id: None,
+                    scheme_id: None
+                },
                 beneficiary: Beneficiary::MerchantAccount {
                     merchant_account_id: "merchant-account-id".to_string(),
                     account_holder_name: None

--- a/src/apis/payments/model.rs
+++ b/src/apis/payments/model.rs
@@ -287,6 +287,9 @@ pub enum AuthorizationFlowNextAction {
         uri: String,
         metadata: Option<RedirectActionMetadata>,
     },
+    Consent {
+        subsequent_action_hint: String,
+    },
     Form {
         inputs: Vec<AdditionalInput>,
     },
@@ -386,6 +389,7 @@ pub enum AdditionalInputImage {
 pub struct AuthorizationFlowConfiguration {
     pub provider_selection: Option<ProviderSelectionSupported>,
     pub redirect: Option<RedirectSupported>,
+    pub consent: Option<ConsentSupported>,
     pub form: Option<FormSupported>,
 }
 
@@ -397,6 +401,9 @@ pub struct RedirectSupported {
     pub return_uri: String,
     pub direct_return_uri: Option<String>,
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+pub struct ConsentSupported {}
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct FormSupported {
@@ -423,6 +430,7 @@ pub struct User {
 pub struct StartAuthorizationFlowRequest {
     pub provider_selection: Option<ProviderSelectionSupported>,
     pub redirect: Option<RedirectSupported>,
+    pub consent: Option<ConsentSupported>,
     pub form: Option<FormSupported>,
 }
 
@@ -440,6 +448,13 @@ pub struct SubmitProviderSelectionActionRequest {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct SubmitProviderSelectionActionResponse {
+    pub authorization_flow: Option<AuthorizationFlow>,
+    #[serde(flatten)]
+    pub status: AuthorizationFlowResponseStatus,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+pub struct SubmitConsentActionResponse {
     pub authorization_flow: Option<AuthorizationFlow>,
     #[serde(flatten)]
     pub status: AuthorizationFlowResponseStatus,

--- a/src/apis/payments/model.rs
+++ b/src/apis/payments/model.rs
@@ -367,12 +367,19 @@ pub enum AuthorizationFlowNextAction {
         metadata: Option<RedirectActionMetadata>,
     },
     Consent {
-        subsequent_action_hint: String,
+        subsequent_action_hint: SubsequentAction,
     },
     Form {
         inputs: Vec<AdditionalInput>,
     },
     Wait,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum SubsequentAction {
+    Redirect,
+    Form,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,8 @@
 //!     .create(&CreatePaymentRequest {
 //!         amount_in_minor: 100,
 //!         currency: Currency::Gbp,
-//!         payment_method: PaymentMethod::BankTransfer {
-//!             provider_selection: ProviderSelection::UserSelected { filter: None },
+//!         payment_method: PaymentMethodRequest::BankTransfer {
+//!             provider_selection: ProviderSelectionRequest::UserSelected { filter: None },
 //!             beneficiary: Beneficiary::MerchantAccount {
 //!                 merchant_account_id: "some-merchant-account-id".to_string(),
 //!                 account_holder_name: None,

--- a/tests/common/mock_server/mod.rs
+++ b/tests/common/mock_server/mod.rs
@@ -24,9 +24,9 @@ use truelayer_rust::apis::{
 };
 use uuid::Uuid;
 
-static MOCK_PROVIDER_ID_REDIRECT: &str = "mock-payments-gb-redirect";
-static MOCK_PROVIDER_ID_ADDITIONAL_INPUTS: &str = "mock-payments-de-redirect-additional-input-text";
-static MOCK_REDIRECT_URI: &str = "https://mock.redirect.uri/";
+const MOCK_PROVIDER_ID_REDIRECT: &str = "mock-payments-gb-redirect";
+const MOCK_PROVIDER_ID_ADDITIONAL_INPUTS: &str = "mock-payments-de-redirect-additional-input-text";
+const MOCK_REDIRECT_URI: &str = "https://mock.redirect.uri/";
 
 #[derive(Clone)]
 struct MockServerConfiguration {
@@ -195,6 +195,15 @@ impl TrueLayerMockServer {
                             true,
                         )))
                         .route(web::post().to(routes::submit_provider_selection)),
+                )
+                .service(
+                    web::resource("/payments/{id}/authorization-flow/actions/consent")
+                        .wrap(MiddlewareFn::new(middlewares::ensure_idempotency_key))
+                        .wrap(MiddlewareFn::new(middlewares::validate_signature(
+                            configuration.clone(),
+                            true,
+                        )))
+                        .route(web::post().to(routes::submit_consent)),
                 )
                 .service(
                     web::resource("/payments/{id}/authorization-flow/actions/form")

--- a/tests/integration_tests/payments.rs
+++ b/tests/integration_tests/payments.rs
@@ -9,9 +9,9 @@ use truelayer_rust::{
             AccountIdentifier, AdditionalInputType, AuthorizationFlow, AuthorizationFlowActions,
             AuthorizationFlowNextAction, AuthorizationFlowResponseStatus, Beneficiary,
             ConsentSupported, CreatePaymentRequest, CreatePaymentUserRequest, Currency,
-            FailureStage, FormSupported, PaymentMethod, PaymentStatus, ProviderSelection,
-            ProviderSelectionSupported, RedirectSupported, StartAuthorizationFlowRequest,
-            StartAuthorizationFlowResponse, SubmitFormActionRequest,
+            FailureStage, FormSupported, PaymentMethodRequest, PaymentStatus,
+            ProviderSelectionRequest, ProviderSelectionSupported, RedirectSupported,
+            StartAuthorizationFlowRequest, StartAuthorizationFlowResponse, SubmitFormActionRequest,
             SubmitProviderReturnParametersRequest, SubmitProviderReturnParametersResponseResource,
             SubmitProviderSelectionActionRequest,
         },
@@ -52,8 +52,8 @@ async fn hpp_link_returns_200() {
         .create(&CreatePaymentRequest {
             amount_in_minor: 1,
             currency: Currency::Gbp,
-            payment_method: PaymentMethod::BankTransfer {
-                provider_selection: ProviderSelection::UserSelected { filter: None },
+            payment_method: PaymentMethodRequest::BankTransfer {
+                provider_selection: ProviderSelectionRequest::UserSelected { filter: None },
                 beneficiary: Beneficiary::MerchantAccount {
                     merchant_account_id: ctx.merchant_account_gbp_id.clone(),
                     account_holder_name: None,
@@ -140,7 +140,7 @@ impl CreatePaymentScenario {
 
         let provider_selection = match &self.provider_selection {
             ScenarioProviderSelection::UserSelected { .. } => {
-                ProviderSelection::UserSelected { filter: None }
+                ProviderSelectionRequest::UserSelected { filter: None }
             }
             ScenarioProviderSelection::Preselected {
                 provider_id,
@@ -162,7 +162,7 @@ impl CreatePaymentScenario {
 
                 assert!(available_schemes.iter().any(|s| &s.id == scheme_id));
 
-                ProviderSelection::Preselected {
+                ProviderSelectionRequest::Preselected {
                     provider_id: provider_id.clone(),
                     scheme_id: scheme_id.clone(),
                     remitter: None,
@@ -174,7 +174,7 @@ impl CreatePaymentScenario {
         let create_payment_request = CreatePaymentRequest {
             amount_in_minor: 1,
             currency: self.currency.clone(),
-            payment_method: PaymentMethod::BankTransfer {
+            payment_method: PaymentMethodRequest::BankTransfer {
                 provider_selection,
                 beneficiary: match self.beneficiary {
                     ScenarioBeneficiary::ClosedLoop => Beneficiary::MerchantAccount {
@@ -228,7 +228,7 @@ impl CreatePaymentScenario {
         assert_eq!(payment.user.phone, None);
         assert_eq!(
             payment.payment_method,
-            create_payment_request.payment_method
+            create_payment_request.payment_method.into()
         );
         assert_eq!(payment.status, PaymentStatus::AuthorizationRequired);
         assert_eq!(

--- a/tests/integration_tests/payments.rs
+++ b/tests/integration_tests/payments.rs
@@ -237,8 +237,8 @@ impl CreatePaymentScenario {
         assert_eq!(payment.user.email.as_deref(), Some("some.one@email.com"));
         assert_eq!(payment.user.phone, None);
         assert_eq!(
-            payment.payment_method,
-            create_payment_request.payment_method.into()
+            PaymentMethodRequest::from(payment.payment_method),
+            create_payment_request.payment_method
         );
         assert_eq!(payment.status, PaymentStatus::AuthorizationRequired);
         assert_eq!(


### PR DESCRIPTION
Add support for the consent action of the payments authorization flow.

Also adds `scheme_id` and `provider_id` to the user selected provider selection response object (by separating the request from the response model).