### PR TITLE
fix: failing acceptance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 The official [TrueLayer](https://truelayer.com) Rust client provides convenient access to TrueLayer APIs from applications built with Rust.
 
+> :warning: **WARNING: This library is currently in alpha**: We do not recommend using this crate for production applications. We plan to create an initial release when the library has caught up with TrueLayer's payments API.
+
 ## Installation
 
 Add the latest version of the library to your project's `Cargo.toml`.

--- a/tests/common/mock_server/mod.rs
+++ b/tests/common/mock_server/mod.rs
@@ -347,7 +347,7 @@ impl TrueLayerMockServer {
             MockBankAction::Cancel => PaymentStatus::Failed {
                 failed_at: Utc::now(),
                 failure_stage: FailureStage::Authorizing,
-                failure_reason: "canceled".to_string(),
+                failure_reason: "not_authorized".to_string(),
                 authorization_flow: Some(next_auth_flow),
             },
         };

--- a/tests/common/test_context/local_mock.rs
+++ b/tests/common/test_context/local_mock.rs
@@ -81,8 +81,8 @@ impl TestContext {
 
     pub async fn submit_provider_return_parameters(
         &self,
-        _query: String,
-        _fragment: String,
+        _query: &str,
+        _fragment: &str,
     ) -> Result<(), anyhow::Error> {
         // This is only necessary for acceptance tests to work correctly.
         // This work is usually done by TrueLayer's SPA upon redirect from the provider.

--- a/tests/common/test_context/local_mock.rs
+++ b/tests/common/test_context/local_mock.rs
@@ -78,4 +78,14 @@ impl TestContext {
             .complete_mock_bank_redirect_authorization(redirect_uri, action)
             .await
     }
+
+    pub async fn submit_provider_return_parameters(
+        &self,
+        _query: String,
+        _fragment: String,
+    ) -> Result<(), anyhow::Error> {
+        // This is only necessary for acceptance tests to work correctly.
+        // This work is usually done by TrueLayer's SPA upon redirect from the provider.
+        Ok(())
+    }
 }

--- a/tests/common/test_context/sandbox.rs
+++ b/tests/common/test_context/sandbox.rs
@@ -86,8 +86,8 @@ impl TestContext {
 
     pub async fn submit_provider_return_parameters(
         &self,
-        query: String,
-        fragment: String,
+        query: &str,
+        fragment: &str,
     ) -> Result<(), anyhow::Error> {
         reqwest::Client::new()
             .post(

--- a/tests/common/test_context/sandbox.rs
+++ b/tests/common/test_context/sandbox.rs
@@ -1,8 +1,11 @@
 use crate::common::MockBankAction;
 use anyhow::Context;
+use serde_json::json;
 use std::str::FromStr;
 use truelayer_rust::{apis::auth::Credentials, client::Environment, TrueLayerClient};
 use url::Url;
+
+static SANDBOX_RETURN_PARAMETERS_URI: &str = "https://pay-api.truelayer-sandbox.com";
 
 pub struct TestContext {
     pub client: TrueLayerClient,
@@ -79,5 +82,28 @@ impl TestContext {
             .await?;
 
         Ok(Url::from_str(&provider_return_uri)?)
+    }
+
+    pub async fn submit_provider_return_parameters(
+        &self,
+        query: String,
+        fragment: String,
+    ) -> Result<(), anyhow::Error> {
+        reqwest::Client::new()
+            .post(
+                Url::parse(SANDBOX_RETURN_PARAMETERS_URI)
+                    .unwrap()
+                    .join("/spa/submit-provider-return-parameters")
+                    .unwrap(),
+            )
+            .json(&json!({
+                "fragment": fragment,
+                "query": query
+            }))
+            .send()
+            .await?
+            .error_for_status()?;
+
+        Ok(())
     }
 }

--- a/tests/integration_tests/payments.rs
+++ b/tests/integration_tests/payments.rs
@@ -442,8 +442,8 @@ impl CreatePaymentScenario {
             );
         } else {
             ctx.submit_provider_return_parameters(
-                provider_return_uri.query().unwrap_or("").to_string(),
-                provider_return_uri.fragment().unwrap_or("").to_string(),
+                provider_return_uri.query().unwrap_or(""),
+                provider_return_uri.fragment().unwrap_or(""),
             )
             .await
             .unwrap()

--- a/tests/integration_tests/payments.rs
+++ b/tests/integration_tests/payments.rs
@@ -440,6 +440,13 @@ impl CreatePaymentScenario {
                     payment_id: res.id.clone()
                 }
             );
+        } else {
+            ctx.submit_provider_return_parameters(
+                provider_return_uri.query().unwrap_or("").to_string(),
+                provider_return_uri.fragment().unwrap_or("").to_string(),
+            )
+            .await
+            .unwrap()
         }
 
         // Wait for the payment to reach a terminal state
@@ -578,10 +585,10 @@ impl CreatePaymentScenario {
     ScenarioBeneficiary::ClosedLoop,
     ScenarioProviderSelection::UserSelected{provider_id: MOCK_PROVIDER_ID_REDIRECT.to_string()},
     MockBankAction::Cancel,
-    ScenarioExpectedStatus::Failed { failure_stage: FailureStage::Authorizing, failure_reason: "canceled" },
+    ScenarioExpectedStatus::Failed { failure_stage: FailureStage::Authorizing, failure_reason: "not_authorized" },
     RedirectFlow::Classic,
     false
-    ; "user selected provider canceled"
+    ; "user selected provider not authorized"
 )]
 #[test_case(
     Currency::Gbp,
@@ -628,10 +635,10 @@ impl CreatePaymentScenario {
     ScenarioBeneficiary::ClosedLoop,
     ScenarioProviderSelection::Preselected{provider_id: MOCK_PROVIDER_ID_REDIRECT.to_string(), scheme_id: "faster_payments_service".to_string()},
     MockBankAction::Cancel,
-    ScenarioExpectedStatus::Failed { failure_stage: FailureStage::Authorizing, failure_reason: "canceled" },
+    ScenarioExpectedStatus::Failed { failure_stage: FailureStage::Authorizing, failure_reason: "not_authorized" },
     RedirectFlow::Classic,
     false
-    ; "preselected provider canceled"
+    ; "preselected provider not authorized"
 )]
 #[test_case(
     Currency::Gbp,
@@ -668,10 +675,10 @@ impl CreatePaymentScenario {
     ScenarioBeneficiary::ClosedLoop,
     ScenarioProviderSelection::UserSelected{provider_id: MOCK_PROVIDER_ID_REDIRECT.to_string()},
     MockBankAction::Cancel,
-    ScenarioExpectedStatus::Failed { failure_stage: FailureStage::Authorizing, failure_reason: "canceled" },
+    ScenarioExpectedStatus::Failed { failure_stage: FailureStage::Authorizing, failure_reason: "not_authorized" },
     RedirectFlow::DirectReturn,
     false
-    ; "user selected provider canceled direct return"
+    ; "user selected provider not authorized direct return"
 )]
 #[test_case(
     Currency::Gbp,
@@ -708,10 +715,10 @@ impl CreatePaymentScenario {
     ScenarioBeneficiary::ClosedLoop,
     ScenarioProviderSelection::Preselected{provider_id: MOCK_PROVIDER_ID_REDIRECT.to_string(), scheme_id: "faster_payments_service".to_string()},
     MockBankAction::Cancel,
-    ScenarioExpectedStatus::Failed { failure_stage: FailureStage::Authorizing, failure_reason: "canceled" },
+    ScenarioExpectedStatus::Failed { failure_stage: FailureStage::Authorizing, failure_reason: "not_authorized" },
     RedirectFlow::DirectReturn,
     false
-    ; "preselected provider canceled direct return"
+    ; "preselected provider not authorized direct return"
 )]
 #[test_case(
     Currency::Gbp,


### PR DESCRIPTION
Several behind-the-scences changes to the API have resulted in some acceptance tests failing.

These changes do not affect any behaviour that is usually exposed to the client and should, therefore, be considered non-breaking. 

This PR fixes the parts of the acceptance tests that emulate some behaviour usually done by TrueLayer's redirect SPA.