### PR TITLE
feat: [PAYG-1219] replace `preferred_scheme_ids` with `scheme_selection`

### DIFF
--- a/examples/create_payment.rs
+++ b/examples/create_payment.rs
@@ -71,7 +71,7 @@ async fn run() -> anyhow::Result<()> {
             payment_method: PaymentMethodRequest::BankTransfer {
                 provider_selection: ProviderSelectionRequest::UserSelected {
                     filter: None,
-                    preferred_scheme_ids: None,
+                    scheme_selection: None,
                 },
                 beneficiary: Beneficiary::MerchantAccount {
                     merchant_account_id: merchant_account.id,

--- a/src/apis/payments/api.rs
+++ b/src/apis/payments/api.rs
@@ -411,7 +411,8 @@ mod tests {
                 CreatePaymentStatus, CreatePaymentUserRequest, Currency, FailureStage,
                 FormSupported, PaymentMethod, PaymentMethodRequest, PaymentStatus, Provider,
                 ProviderSelection, ProviderSelectionRequest, ProviderSelectionSupported,
-                RedirectSupported, SubmitProviderReturnParametersResponseResource, User,
+                RedirectSupported, SchemeSelection, SubmitProviderReturnParametersResponseResource,
+                User,
             },
         },
         authenticator::Authenticator,
@@ -468,9 +469,10 @@ mod tests {
                     "type": "bank_transfer",
                     "provider_selection": {
                         "type": "user_selected",
-                        "preferred_scheme_ids": [
-                            "faster_payments_service"
-                        ]
+                        "scheme_selection": {
+                            "type": "instant_only",
+                            "allow_remitter_fee": true
+                        }
                     },
                     "beneficiary": {
                         "type": "merchant_account",
@@ -500,7 +502,9 @@ mod tests {
                 payment_method: PaymentMethodRequest::BankTransfer {
                     provider_selection: ProviderSelectionRequest::UserSelected {
                         filter: None,
-                        preferred_scheme_ids: Some(vec!["faster_payments_service".to_string()]),
+                        scheme_selection: Some(SchemeSelection::InstantOnly {
+                            allow_remitter_fee: Some(true),
+                        }),
                     },
                     beneficiary: Beneficiary::MerchantAccount {
                         merchant_account_id: "merchant-account-id".to_string(),
@@ -887,7 +891,7 @@ mod tests {
             PaymentMethod::BankTransfer {
                 provider_selection: ProviderSelection::UserSelected {
                     filter: None,
-                    preferred_scheme_ids: None,
+                    scheme_selection: None,
                     provider_id: None,
                     scheme_id: None
                 },

--- a/src/apis/payments/model.rs
+++ b/src/apis/payments/model.rs
@@ -46,7 +46,7 @@ impl From<PaymentMethod> for PaymentMethodRequest {
 pub enum ProviderSelectionRequest {
     UserSelected {
         filter: Option<ProviderFilter>,
-        preferred_scheme_ids: Option<Vec<String>>,
+        scheme_selection: Option<SchemeSelection>,
     },
     Preselected {
         provider_id: String,
@@ -61,11 +61,11 @@ impl From<ProviderSelection> for ProviderSelectionRequest {
         match p {
             ProviderSelection::UserSelected {
                 filter,
-                preferred_scheme_ids,
+                scheme_selection,
                 ..
             } => ProviderSelectionRequest::UserSelected {
                 filter,
-                preferred_scheme_ids,
+                scheme_selection,
             },
             ProviderSelection::Preselected {
                 provider_id,
@@ -283,7 +283,7 @@ pub struct SettlementRisk {
 pub enum ProviderSelection {
     UserSelected {
         filter: Option<ProviderFilter>,
-        preferred_scheme_ids: Option<Vec<String>>,
+        scheme_selection: Option<SchemeSelection>,
         provider_id: Option<String>,
         scheme_id: Option<String>,
     },
@@ -292,6 +292,13 @@ pub enum ProviderSelection {
         scheme_id: String,
         remitter: Option<Remitter>,
     },
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SchemeSelection {
+    InstantOnly { allow_remitter_fee: Option<bool> },
+    InstantPreferred { allow_remitter_fee: Option<bool> },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 //!         amount_in_minor: 100,
 //!         currency: Currency::Gbp,
 //!         payment_method: PaymentMethodRequest::BankTransfer {
-//!             provider_selection: ProviderSelectionRequest::UserSelected { filter: None, preferred_scheme_ids: None },
+//!             provider_selection: ProviderSelectionRequest::UserSelected { filter: None, scheme_selection: None },
 //!             beneficiary: Beneficiary::MerchantAccount {
 //!                 merchant_account_id: "some-merchant-account-id".to_string(),
 //!                 account_holder_name: None,

--- a/tests/common/mock_server/routes.rs
+++ b/tests/common/mock_server/routes.rs
@@ -82,10 +82,10 @@ pub(super) async fn create_payment(
             provider_selection: match provider_selection {
                 ProviderSelectionRequest::UserSelected {
                     filter,
-                    preferred_scheme_ids,
+                    scheme_selection,
                 } => ProviderSelection::UserSelected {
                     filter,
-                    preferred_scheme_ids,
+                    scheme_selection,
                     provider_id: None,
                     scheme_id: None,
                 },

--- a/tests/integration_tests/payments.rs
+++ b/tests/integration_tests/payments.rs
@@ -54,7 +54,7 @@ async fn hpp_link_returns_200() {
             payment_method: PaymentMethodRequest::BankTransfer {
                 provider_selection: ProviderSelectionRequest::UserSelected {
                     filter: None,
-                    preferred_scheme_ids: None,
+                    scheme_selection: None,
                 },
                 beneficiary: Beneficiary::MerchantAccount {
                     merchant_account_id: ctx.merchant_account_gbp_id.clone(),
@@ -143,10 +143,7 @@ impl CreatePaymentScenario {
             ScenarioProviderSelection::UserSelected { .. } => {
                 ProviderSelectionRequest::UserSelected {
                     filter: None,
-                    preferred_scheme_ids: match self.currency {
-                        Currency::Gbp => Some(vec!["faster_payments_service".into()]),
-                        Currency::Eur => Some(vec!["sepa_credit_transfer_instant".into()]),
-                    },
+                    scheme_selection: None,
                 }
             }
             ScenarioProviderSelection::Preselected {


### PR DESCRIPTION
Replaces the deprecated `preferred_scheme_ids` with new `scheme_selection`.