### PR TITLE
feat(PAYG-1374): Remove user info from get payment response

### DIFF
--- a/src/apis/payments/api.rs
+++ b/src/apis/payments/api.rs
@@ -904,10 +904,7 @@ mod tests {
         assert_eq!(
             payment.user,
             User {
-                id: "user-id".to_string(),
-                name: None,
-                email: None,
-                phone: None
+                id: "user-id".to_string()
             }
         );
         assert_eq!(payment.status, PaymentStatus::AuthorizationRequired);

--- a/src/apis/payments/model.rs
+++ b/src/apis/payments/model.rs
@@ -523,10 +523,7 @@ pub enum AdditionalInputType {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct User {
-    pub id: String,
-    pub name: Option<String>,
-    pub email: Option<String>,
-    pub phone: Option<String>,
+    pub id: String
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]

--- a/tests/common/mock_server/routes.rs
+++ b/tests/common/mock_server/routes.rs
@@ -61,17 +61,11 @@ pub(super) async fn create_payment(
 ) -> HttpResponse {
     let id = Uuid::new_v4().to_string();
     let user = match create_payment_request.user.clone() {
-        CreatePaymentUserRequest::NewUser { name, email, phone } => User {
-            id: "payment-source-user-id".to_string(),
-            name,
-            email,
-            phone,
+        CreatePaymentUserRequest::NewUser { name: _, email: _, phone: _ } => User {
+            id: "payment-source-user-id".to_string()
         },
         CreatePaymentUserRequest::ExistingUser { id } => User {
-            id,
-            name: None,
-            email: None,
-            phone: None,
+            id
         },
     };
 

--- a/tests/integration_tests/payments.rs
+++ b/tests/integration_tests/payments.rs
@@ -237,9 +237,6 @@ impl CreatePaymentScenario {
         assert_eq!(payment.amount_in_minor, 1);
         assert_eq!(payment.currency, self.currency);
         assert_eq!(payment.user.id, res.user.id);
-        assert_eq!(payment.user.name.as_deref(), Some("someone"));
-        assert_eq!(payment.user.email.as_deref(), Some("some.one@email.com"));
-        assert_eq!(payment.user.phone, None);
         assert_eq!(
             PaymentMethodRequest::from(payment.payment_method),
             create_payment_request.payment_method


### PR DESCRIPTION
**Description:**
Remove user info from the GET /payment response.

**Changelog:**
https://docs.truelayer.com/changelog/removal-of-user-info-in-payment-and-mandate-response

**Updated documentation**
https://docs.truelayer.com/reference/get-payment-1
https://docs.truelayer.com/reference/get-mandate