### PR TITLE
feat: [MAPS-1487] Add missing references to Merchant Account Payment and External Payment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "truelayer-rust"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ let res = tl
             beneficiary: Beneficiary::MerchantAccount {
                 merchant_account_id: "some-merchant-account-id".to_string(),
                 account_holder_name: None,
+                reference: None,
+                statement_reference: None,
             },
         },
         user: User {

--- a/examples/create_payment.rs
+++ b/examples/create_payment.rs
@@ -76,6 +76,8 @@ async fn run() -> anyhow::Result<()> {
                 beneficiary: Beneficiary::MerchantAccount {
                     merchant_account_id: merchant_account.id,
                     account_holder_name: None,
+                    reference: None,
+                    statement_reference: None,
                 },
             },
             user: CreatePaymentUserRequest::NewUser {

--- a/src/apis/merchant_accounts/api.rs
+++ b/src/apis/merchant_accounts/api.rs
@@ -774,9 +774,9 @@ mod tests {
                         "currency": "GBP",
                         "amount_in_minor": 100,
                         "type": "payout",
-                        "status": "settled",
+                        "status": "executed",
                         "created_at": &now,
-                        "settled_at": &now,
+                        "executed_at": &now,
                         "beneficiary": {
                             "type": "payment_source",
                             "user_id": "payout-user-id",
@@ -867,7 +867,7 @@ mod tests {
                     currency: Currency::Gbp,
                     amount_in_minor: 100,
                     r#type: TransactionType::Payout {
-                        status: TransactionPayoutStatus::Settled { settled_at: now },
+                        status: TransactionPayoutStatus::Executed { executed_at: now },
                         created_at: now,
                         beneficiary: PayoutBeneficiary::PaymentSource {
                             user_id: "payout-user-id".to_string(),

--- a/src/apis/merchant_accounts/api.rs
+++ b/src/apis/merchant_accounts/api.rs
@@ -263,7 +263,7 @@ mod tests {
                 SweepingFrequency, TransactionPayinStatus, TransactionPayoutContextCode,
                 TransactionPayoutStatus, TransactionType,
             },
-            payments::{AccountIdentifier, Currency, Remitter},
+            payments::{AccountIdentifier, Currency, ExternalPaymentRemitter},
             payouts::PayoutBeneficiary,
         },
         authenticator::Authenticator,
@@ -745,7 +745,8 @@ mod tests {
                                 "sort_code": "sort-code",
                                 "account_number": "account-number"
                             },
-                            "account_holder_name": "Mr. Holder"
+                            "account_holder_name": "Mr. Holder",
+                            "reference": "ext-payment-ref"
                         }
                     },
                     {
@@ -832,12 +833,13 @@ mod tests {
                     r#type: TransactionType::ExternalPayment {
                         status: TransactionPayinStatus::Settled,
                         settled_at: now,
-                        remitter: Remitter {
+                        remitter: ExternalPaymentRemitter {
                             account_holder_name: Some("Mr. Holder".into()),
                             account_identifier: Some(AccountIdentifier::SortCodeAccountNumber {
                                 sort_code: "sort-code".to_string(),
                                 account_number: "account-number".to_string()
-                            })
+                            }),
+                            reference: Some("ext-payment-ref".to_string())
                         }
                     }
                 },

--- a/src/apis/merchant_accounts/api.rs
+++ b/src/apis/merchant_accounts/api.rs
@@ -834,12 +834,12 @@ mod tests {
                         status: TransactionPayinStatus::Settled,
                         settled_at: now,
                         remitter: ExternalPaymentRemitter {
-                            account_holder_name: Some("Mr. Holder".into()),
-                            account_identifier: Some(AccountIdentifier::SortCodeAccountNumber {
+                            account_holder_name: "Mr. Holder".into(),
+                            account_identifier: AccountIdentifier::SortCodeAccountNumber {
                                 sort_code: "sort-code".to_string(),
                                 account_number: "account-number".to_string()
-                            }),
-                            reference: Some("ext-payment-ref".to_string())
+                            },
+                            reference: "ext-payment-ref".to_string()
                         }
                     }
                 },

--- a/src/apis/merchant_accounts/model.rs
+++ b/src/apis/merchant_accounts/model.rs
@@ -1,5 +1,5 @@
 use crate::apis::{
-    payments::{AccountIdentifier, Currency, PaymentSource, Remitter},
+    payments::{AccountIdentifier, Currency, ExternalPaymentRemitter, PaymentSource},
     payouts::PayoutBeneficiary,
 };
 use chrono::{DateTime, SecondsFormat, Utc};
@@ -80,7 +80,7 @@ pub enum TransactionType {
     ExternalPayment {
         status: TransactionPayinStatus,
         settled_at: DateTime<Utc>,
-        remitter: Remitter,
+        remitter: ExternalPaymentRemitter,
     },
     Payout {
         #[serde(flatten)]

--- a/src/apis/merchant_accounts/model.rs
+++ b/src/apis/merchant_accounts/model.rs
@@ -102,7 +102,7 @@ pub enum TransactionPayinStatus {
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum TransactionPayoutStatus {
     Pending,
-    Settled { settled_at: DateTime<Utc> },
+    Executed { executed_at: DateTime<Utc> },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Hash)]

--- a/src/apis/payments/api.rs
+++ b/src/apis/payments/api.rs
@@ -476,7 +476,7 @@ mod tests {
                     },
                     "beneficiary": {
                         "type": "merchant_account",
-                        "merchant_account_id": "merchant-account-id"
+                        "merchant_account_id": "merchant-account-id",
                     },
                 },
                 "user": {
@@ -509,6 +509,8 @@ mod tests {
                     beneficiary: Beneficiary::MerchantAccount {
                         merchant_account_id: "merchant-account-id".to_string(),
                         account_holder_name: None,
+                        reference: None,
+                        statement_reference: None,
                     },
                 },
                 user: CreatePaymentUserRequest::ExistingUser {
@@ -897,7 +899,9 @@ mod tests {
                 },
                 beneficiary: Beneficiary::MerchantAccount {
                     merchant_account_id: "merchant-account-id".to_string(),
-                    account_holder_name: None
+                    account_holder_name: None,
+                    reference: None,
+                    statement_reference: None
                 }
             }
         );

--- a/src/apis/payments/model.rs
+++ b/src/apis/payments/model.rs
@@ -315,9 +315,9 @@ pub struct Remitter {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct ExternalPaymentRemitter {
-    pub account_holder_name: Option<String>,
-    pub account_identifier: Option<AccountIdentifier>,
-    pub reference: Option<String>,
+    pub account_holder_name: String,
+    pub account_identifier: AccountIdentifier,
+    pub reference: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]

--- a/src/apis/payments/model.rs
+++ b/src/apis/payments/model.rs
@@ -251,6 +251,8 @@ pub enum Beneficiary {
     MerchantAccount {
         merchant_account_id: String,
         account_holder_name: Option<String>,
+        reference: Option<String>,
+        statement_reference: Option<String>,
     },
     ExternalAccount {
         account_holder_name: String,
@@ -309,6 +311,13 @@ pub enum SchemeSelection {
 pub struct Remitter {
     pub account_holder_name: Option<String>,
     pub account_identifier: Option<AccountIdentifier>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+pub struct ExternalPaymentRemitter {
+    pub account_holder_name: Option<String>,
+    pub account_identifier: Option<AccountIdentifier>,
+    pub reference: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,8 @@
 //!             beneficiary: Beneficiary::MerchantAccount {
 //!                 merchant_account_id: "some-merchant-account-id".to_string(),
 //!                 account_holder_name: None,
+//!                 reference: None,
+//!                 statement_reference: None,
 //!             },
 //!         },
 //!         user: CreatePaymentUserRequest::NewUser {

--- a/tests/integration_tests/helpers.rs
+++ b/tests/integration_tests/helpers.rs
@@ -34,6 +34,8 @@ pub async fn create_closed_loop_payment(
                 beneficiary: Beneficiary::MerchantAccount {
                     merchant_account_id: ctx.merchant_account_gbp_id.clone(),
                     account_holder_name: None,
+                    reference: None,
+                    statement_reference: None,
                 },
             },
             user: CreatePaymentUserRequest::NewUser {

--- a/tests/integration_tests/payments.rs
+++ b/tests/integration_tests/payments.rs
@@ -61,6 +61,8 @@ async fn hpp_link_returns_200() {
                 beneficiary: Beneficiary::MerchantAccount {
                     merchant_account_id: ctx.merchant_account_gbp_id.clone(),
                     account_holder_name: None,
+                    reference: None,
+                    statement_reference: None,
                 },
             },
             user: CreatePaymentUserRequest::NewUser {
@@ -193,6 +195,8 @@ impl CreatePaymentScenario {
                     ScenarioBeneficiary::ClosedLoop => Beneficiary::MerchantAccount {
                         merchant_account_id: ctx.merchant_account_gbp_id.clone(),
                         account_holder_name: None,
+                        reference: Some("Reference".to_string()),
+                        statement_reference: Some("StReference".to_string()),
                     },
                     ScenarioBeneficiary::OpenLoop {
                         ref account_identifier,


### PR DESCRIPTION
[Create payment](https://docs.truelayer.com/reference/create-payment) allows passing two references:
- reference
- statement_reference

We aren't supporting neither of the two.
![image](https://github.com/user-attachments/assets/b64d74d0-3305-43a7-9b4a-bb4536a22c6a)

We should also return the reference in the External Payment transaction, something we are not doing at the moment.
![image](https://github.com/user-attachments/assets/5b7c6404-3d3b-4cc7-a083-effbf716e323)
